### PR TITLE
Fix is_process_alive failing call.

### DIFF
--- a/src/riak_pg_members_fsm.erl
+++ b/src/riak_pg_members_fsm.erl
@@ -175,7 +175,19 @@ finalize(timeout, #state{replies=Replies}=State) ->
 %% @doc If the node is connected, and the process is not alive, prune
 %%      it.
 prune_pid(Pid) when is_pid(Pid) ->
-    lists:member(node(Pid), nodes()) andalso (is_process_alive(Pid) =:= false).
+    lists:member(node(Pid), nodes()) andalso
+        (is_process_alive(node(Pid), Pid) =:= false).
+
+%% @doc Remote call to determine if process is alive or not; assume if
+%%      the node fails communication it is, since we have no proof it
+%%      is not.
+is_process_alive(Node, Pid) ->
+    case rpc:call(Node, erlang, is_process_alive, [Pid]) of
+        {badrpc, _} ->
+            true;
+        Value ->
+            Value
+    end.
 
 %% @doc Based on connected nodes, prune out processes that no longer
 %%      exist.


### PR DESCRIPTION
Remote call; since this will fail to return true on a live node. Thanks @rvirding!
